### PR TITLE
Implements API endpoints, frontend profile rendering, and stub for similar poius  

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -39,4 +39,3 @@ In the `backend` directory you need to the following in the terminal (with your 
 Create your flask routes in `server.py`
 
 Important note here you need to have both the frontend and the backend running at the same time for this to work properly.
-s

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,3 +39,4 @@ In the `backend` directory you need to the following in the terminal (with your 
 Create your flask routes in `server.py`
 
 Important note here you need to have both the frontend and the backend running at the same time for this to work properly.
+s

--- a/backend/import_all_data.py
+++ b/backend/import_all_data.py
@@ -12,11 +12,11 @@ def main():
     print("Importing data to database...")
     with app.app_context():
         # with this import script just comment out the ones that fail.
-        # import_season(db, Season)
-        # import_games_for_season("2023", db, Game)
-        # import_all_shots(db, Shot, Game)
-        # import_players_for_season("2023", db, Player)
-        # import_shifts_for_games(db, Game)
+        import_season(db, Season)
+        import_games_for_season("2023", db, Game)
+        import_all_shots(db, Shot, Game)
+        import_players_for_season("2023", db, Player)
+        import_shifts_for_games(db, Game)
         import_poiu_to_shot_mapping(db, Shot, Player, POIU, get_or_create)
 
     print("Importing all data succesful!")

--- a/backend/import_all_data.py
+++ b/backend/import_all_data.py
@@ -6,18 +6,17 @@ from import_scripts.import_shifts import import_shifts_for_games
 from import_scripts.import_poiu import import_poiu_to_shot_mapping
 from app import app, db
 from models import Season, Game, Shot, Player, POIU, get_or_create
-import os,sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '.')))
+
 
 def main():
     print("Importing data to database...")
     with app.app_context():
         # with this import script just comment out the ones that fail.
-        import_season(db, Season)
-        import_games_for_season("2023", db, Game)
-        import_all_shots(db, Shot, Game)
-        import_players_for_season("2023", db, Player)
-        import_shifts_for_games(db, Game)
+        # import_season(db, Season)
+        # import_games_for_season("2023", db, Game)
+        # import_all_shots(db, Shot, Game)
+        # import_players_for_season("2023", db, Player)
+        # import_shifts_for_games(db, Game)
         import_poiu_to_shot_mapping(db, Shot, Player, POIU, get_or_create)
 
     print("Importing all data succesful!")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 colorama==0.4.6
 Flask==3.1.0
+flask-cors==5.0.1
 Flask-SQLAlchemy==3.1.1
 greenlet==3.1.1
 idna==3.10

--- a/backend/server.py
+++ b/backend/server.py
@@ -35,12 +35,12 @@ def search_players():
 
 # Note: new paths will be added below.
 
+# get units that generate the most shots by a a player id and a situation.
 @app.route("/get_units_by_player_id", methods=("GET",))
 def get_units_by_player_id():
     player_id = request.args.to_dict().get("player_id")
     situation = request.args.to_dict().get("situation")
 
-    # get units by
     unit_sql_query = F"""
         SELECT
             poiu.id,
@@ -88,6 +88,7 @@ def get_units_by_player_id():
 
     return jsonify(unit_ids)
 
+# gets all of the players in lists of forwards and dmen (for easier frontend parsing)
 @app.route("/get_players_by_poiu", methods=("GET",))
 def get_players_by_poiu():
     poiu = request.args.to_dict().get("poiu")

--- a/frontend/components/charts/BarChart.js
+++ b/frontend/components/charts/BarChart.js
@@ -8,8 +8,6 @@ export default function BarChart(
 
   const ref = useRef();
   useEffect(()=> {
-
-    console.log("BarChart")
     createOrUpdateBarChart()
   }, [])
 

--- a/frontend/components/controls/SituationTabs.js
+++ b/frontend/components/controls/SituationTabs.js
@@ -1,17 +1,28 @@
 
 import {
   Tabs,
-  TabsContent,
+
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs"
 
+import { useGlobalState } from "../state_providers/GlobalState"
+
 
 export default function SituationTabs() {
+
+  const {currentSituation, setCurrentSituation} = useGlobalState()
+
+
   return <div className="w-full mb-2 flex justify-center">
      <h1 className="text-xl font-bold text-center mb-8 mr-3">POIU Situation</h1>
-    <Tabs defaultValue="5on5" className="w-[400px]">
-      <TabsList className="grid text-center grid-cols-4">
+    <Tabs defaultValue="5on5" className="w-[400px]"
+      value={currentSituation}
+      onValueChange={setCurrentSituation}
+    >
+      <TabsList className="grid text-center grid-cols-4"
+
+      >
         <TabsTrigger value="5on5">5 on 5</TabsTrigger>
         <TabsTrigger value="5on4">PowerPlay </TabsTrigger>
         <TabsTrigger value="4on5">Penalty Kill</TabsTrigger>

--- a/frontend/components/player/PlayerProfile.js
+++ b/frontend/components/player/PlayerProfile.js
@@ -1,3 +1,6 @@
+import {
+  useQuery,
+} from '@tanstack/react-query'
 
 import { Card, CardContent } from "@/components/ui/card"
 
@@ -5,9 +8,8 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 
 import { Badge } from "@/components/ui/badge"
 
-import {
-  useQuery,
-} from '@tanstack/react-query'
+import { useGlobalState } from '../state_providers/GlobalState'
+
 
 const longPosition = (oneCharValue) => {
   if (oneCharValue === "C") return "Center"
@@ -17,7 +19,9 @@ const longPosition = (oneCharValue) => {
 }
 
 // takes in the id of the player based on nhl.com's id
-export default function PlayerProfile ({playerId, isSearchResult}) {
+export default function PlayerProfile ({playerId, isSearchResult, clearSearch}) {
+  const {currentPlayer, setCurrentPlayer} = useGlobalState()
+
   const { isPending, error, data } = useQuery({
     queryKey: [`player-${playerId}`],
     queryFn: async () => {
@@ -29,6 +33,13 @@ export default function PlayerProfile ({playerId, isSearchResult}) {
     staleTime: Infinity,
   })
 
+  // this is to select the player
+  const selectPlayer = () => {
+    // sets the player to the current object
+    setCurrentPlayer(data)
+    clearSearch()
+  }
+
   if (isPending) return 'Loading...'
 
   if (error) return 'An error has occurred: ' + error.message
@@ -36,23 +47,30 @@ export default function PlayerProfile ({playerId, isSearchResult}) {
   const playerName = `${data.firstName.default} ${data.lastName.default}`
 
   if (isSearchResult) {
-    return  <Card key={playerId} className="overflow-hidden">
+    if (!data) {
+      return <></>
+    }
+    return  <Card
+      key={playerId} className="overflow-hidden"
+      onClick={selectPlayer}
+    >
       <CardContent className="p-4">
         <div className="flex items-center space-x-4">
           <Avatar>
             <AvatarImage src={data.headshot} alt={playerName} />
             <AvatarFallback>{playerName.substring(0, 2)}</AvatarFallback>
           </Avatar>
+
           <div className="flex-1 space-y-1">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium leading-none">
-                {playerName} <span className="text-muted-foreground">#{data.sweaterNumbe}</span>
+            <div className="flex  items-center justify-between">
+              <p className="text-sm grow-1 font-medium leading-none">
+                {playerName} <span className="text-muted-foreground">#{data.sweaterNumber}</span>
               </p>
+              <p className="flex text-sm text-muted-foreground">{data.fullTeamName?.default}</p>
               <div className="rounded-full bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
                 {data.position}
               </div>
             </div>
-            {/* <p className="text-sm text-muted-foreground">{player.team}</p> */}
           </div>
         </div>
       </CardContent>

--- a/frontend/components/player/PlayerSearchInput.js
+++ b/frontend/components/player/PlayerSearchInput.js
@@ -50,11 +50,6 @@ export default function PlayerSearchInput () {
     setSearchResults([])
   }
 
-  // if (isPending) {
-  //   return "Searching..."
-  // }
-
-
   return <div className="w-full max-w-3xl mx-auto p-4">
     <div className="flex flex-col space-y-4">
       <h1 className="text-2xl font-bold">NHL Player Search</h1>

--- a/frontend/components/player/PlayerSearchInput.js
+++ b/frontend/components/player/PlayerSearchInput.js
@@ -18,6 +18,7 @@ export default function PlayerSearchInput () {
   const [searchQuery, setSearchQuery] = useState("")
   const [searchResults, setSearchResults] = useState([])
 
+  // this is all for the search
   let { isPending, error, data, refetch } = useQuery({
     queryKey: [`search-results`],
     queryFn: async ()=> {
@@ -26,15 +27,10 @@ export default function PlayerSearchInput () {
     enabled: searchQuery.length >= 3,
     staleTime: Infinity,
   })
-
-  const handleSearch = async () => {
-
-  }
-  useEffect(()=> {
+  const handleSearch =  () => {
     if (searchQuery.length >= 3) {
       // const data = await searchPlayers({name: searchQuery})
       refetch()
-      console.log(data)
       if (data) {
         setSearchResults(data.players)
       }
@@ -42,8 +38,22 @@ export default function PlayerSearchInput () {
     } else {
       setSearchResults([])
     }
-
+  }
+  useEffect(()=> {
+    handleSearch()
   }, [searchQuery])
+  // end the search section
+
+  // pass this down to clear the search once user selects it.
+  const clearSearch = () => {
+    setSearchQuery("")
+    setSearchResults([])
+  }
+
+  // if (isPending) {
+  //   return "Searching..."
+  // }
+
 
   return <div className="w-full max-w-3xl mx-auto p-4">
     <div className="flex flex-col space-y-4">
@@ -63,13 +73,15 @@ export default function PlayerSearchInput () {
         <Button onClick={handleSearch}>Search</Button>
       </div>
       <div className="space-y-3">
-        {
+        { searchResults &&
           searchResults.map((player)=> {
-            console.log(player)
+            if (!player) return
             return <PlayerProfile
               key={player.id}
-              isSearchResult={true}
               playerId={player.id}
+              // these two are only for search.
+              isSearchResult={true}
+              clearSearch={clearSearch}
             />
           })
         }

--- a/frontend/components/poiu/POIUPlayerProfiles.js
+++ b/frontend/components/poiu/POIUPlayerProfiles.js
@@ -1,0 +1,67 @@
+import {useEffect} from 'react'
+import {
+  useQuery,
+  useQueryClient
+} from '@tanstack/react-query'
+
+import PlayerProfile from "../player/PlayerProfile"
+
+import { useGlobalState } from "../state_providers/GlobalState"
+
+import { getPlayersByPoiu } from '@/utils/api/players'
+
+// this is just going to show the head shots.
+export default function POIUPlayerProfiles({unitId}) {
+  const queryClient = useQueryClient();
+  const {
+    currentPlayerPOIU
+  } = useGlobalState()
+  const queryKey = `all-player-profiles-${unitId}`
+
+  let { isLoading, error, data, refetch } = useQuery({
+    queryKey: [queryKey],
+    queryFn: async () => {
+      return await getPlayersByPoiu({poiuId: unitId})
+    },
+    enabled: false, // this will only fetch once you get a player
+    staleTime: Infinity,
+  })
+
+  useEffect(()=> {
+    if (!unitId) return // guard
+    console.log("POIUPlayerProfiles")
+    console.log("unitId", unitId)
+    queryClient.invalidateQueries(queryKey)
+    refetch()
+  },[currentPlayerPOIU, unitId])
+
+  if (isLoading) {
+    return "Loading profiles..."
+  }
+
+  if (!data) {
+    return <></>
+  }
+
+  return <>
+    {/* Forwards */}
+    <div className="flex items-center w-full justify-between gap-2">
+
+      {data.forwards?.map((player)=> {
+        return <PlayerProfile
+          key={player.id}
+          playerId={player.id}
+        />
+      })}
+    </div>
+    {/* defensemen */}
+    <div className="flex items-center w-3/5 justify-between gap-2">
+      {data.defensemen?.map((player)=> {
+        return <PlayerProfile
+          key={player.id}
+          playerId={player.id}
+        />
+      })}
+    </div>
+  </>
+}

--- a/frontend/components/poiu/POIUnitCard.js
+++ b/frontend/components/poiu/POIUnitCard.js
@@ -1,12 +1,12 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 
-import PlayerProfile from "../player/PlayerProfile"
 import POIUnitAnalysis from "./POIUnitAnalysis"
 import POIUPlayerProfiles from './POIUPlayerProfiles'
 import { useGlobalState } from '../state_providers/GlobalState'
 
 
+// this component is used on both similar matches and player match poius.
 export default function POIUnitCard({unitId, team, isPlayerMatchPOIU, isSimilarMatchPOIU}) {
 
   const {
@@ -25,9 +25,9 @@ export default function POIUnitCard({unitId, team, isPlayerMatchPOIU, isSimilarM
     units = allPlayerMatchPOIUs
   } else if (isSimilarMatchPOIU) {
     units = allSimilarPOIUs
-
   }
 
+  // sets the current poiu for player match and similarities
   const handleUnitChange = (value) => {
     if (isPlayerMatchPOIU) {
       setCurrentPlayerPOIU(value)
@@ -41,25 +41,18 @@ export default function POIUnitCard({unitId, team, isPlayerMatchPOIU, isSimilarM
   let fullName = ""
   if (currentPlayer) {
     fullName = `${currentPlayer.firstName.default} ${currentPlayer.lastName.default}`
-
   }
   // current unit is used for all of the analytics tables and charts
   // essentially we'll be fetching the data based on this.
-  let currentUnit;
+  let currentUnit
   let title
   if (isPlayerMatchPOIU) {
-    console.log("isPlayerMatchPOIU")
     currentUnit = currentPlayerPOIU
     title=`${fullName}'s POIU best match ${unitAsRankForTitle}`
   } else if (isSimilarMatchPOIU) {
-    console.log("isSimilarMatchPOIU")
     currentUnit = currentSimilarPOIU
     title=`Similar POIUs to ${fullName} best match ${unitAsRankForTitle}`
   }
-  console.log(isPlayerMatchPOIU)
-  console.log(isSimilarMatchPOIU)
-  console.log("current unit", currentSimilarPOIU)
-  console.log("unitId", unitId)
 
   if (!currentUnit) {
     return <></>

--- a/frontend/components/poiu/POIUnitCard.js
+++ b/frontend/components/poiu/POIUnitCard.js
@@ -3,17 +3,67 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 
 import PlayerProfile from "../player/PlayerProfile"
 import POIUnitAnalysis from "./POIUnitAnalysis"
+import POIUPlayerProfiles from './POIUPlayerProfiles'
+import { useGlobalState } from '../state_providers/GlobalState'
 
 
-export default function POIUnitCard({title, team, id}) {
+export default function POIUnitCard({unitId, team, isPlayerMatchPOIU, isSimilarMatchPOIU}) {
 
-  const DUMMY_UNITS = [
-    "Unit: 1",
-    "Unit: 2",
-    "Unit: 3",
-    "Unit: 4",
-    "Unit: 5"
-  ]
+  const {
+    currentPlayer,
+    currentPlayerPOIU,
+    currentSimilarPOIU,
+    setCurrentPlayerPOIU,
+    setCurrentSimilarPOIU,
+    allPlayerMatchPOIUs,
+    allSimilarPOIUs,
+  } = useGlobalState()
+
+  let units  = []
+  // using the same card for player match and similarities
+  if (isPlayerMatchPOIU) {
+    units = allPlayerMatchPOIUs
+  } else if (isSimilarMatchPOIU) {
+    units = allSimilarPOIUs
+
+  }
+
+  const handleUnitChange = (value) => {
+    if (isPlayerMatchPOIU) {
+      setCurrentPlayerPOIU(value)
+    } else if (isSimilarMatchPOIU) {
+      setCurrentSimilarPOIU(value)
+    }
+  }
+
+  // just used for titles.
+  let unitAsRankForTitle = allPlayerMatchPOIUs.indexOf(currentPlayerPOIU)+1
+  let fullName = ""
+  if (currentPlayer) {
+    fullName = `${currentPlayer.firstName.default} ${currentPlayer.lastName.default}`
+
+  }
+  // current unit is used for all of the analytics tables and charts
+  // essentially we'll be fetching the data based on this.
+  let currentUnit;
+  let title
+  if (isPlayerMatchPOIU) {
+    console.log("isPlayerMatchPOIU")
+    currentUnit = currentPlayerPOIU
+    title=`${fullName}'s POIU best match ${unitAsRankForTitle}`
+  } else if (isSimilarMatchPOIU) {
+    console.log("isSimilarMatchPOIU")
+    currentUnit = currentSimilarPOIU
+    title=`Similar POIUs to ${fullName} best match ${unitAsRankForTitle}`
+  }
+  console.log(isPlayerMatchPOIU)
+  console.log(isSimilarMatchPOIU)
+  console.log("current unit", currentSimilarPOIU)
+  console.log("unitId", unitId)
+
+  if (!currentUnit) {
+    return <></>
+  }
 
   return <Card className="border-t-8">
     <CardHeader
@@ -25,48 +75,27 @@ export default function POIUnitCard({title, team, id}) {
           <CardDescription>{team}</CardDescription>
         </div>
         {/* Units will have to be changed a bit differently */}
-        <Select className="flex-none" value={""} onValueChange={()=>{}}>
+        <Select className="flex-none" value={""} onValueChange={handleUnitChange}>
           <SelectTrigger className="w-[200px]">
             <SelectValue placeholder="Select different POIU" />
           </SelectTrigger>
           <SelectContent>
-            {DUMMY_UNITS.map((dummyUnit, index)=> {
-
-               return <SelectItem key={dummyUnit} value={dummyUnit}>
+            {units?.map((unit, index)=> {
+               return <SelectItem key={unit} value={unit}>
                 <div className="flex items-center gap-2">
                   <div className="w-3 h-3 rounded-full" />
-                  {dummyUnit}
+                  Best unit match {index+ 1}
                 </div>
               </SelectItem>
             })}
           </SelectContent>
         </Select>
-
       </div>
       {/* forwards handle if it's 4 */}
-      <div className="flex items-center w-full justify-between gap-2">
-        <PlayerProfile
-          playerId={8475786}
-        />
-        <PlayerProfile
-          playerId={8478402}
-        />
-        <PlayerProfile
-          playerId={8479318}
-        />
-      </div>
-      {/* defensemen */}
-      <div className="flex items-center w-3/5 justify-between gap-2">
-        <PlayerProfile
-          playerId={8480803}
-        />
-        <PlayerProfile
-          playerId={8475218}
-        />
-      </div>
+      <POIUPlayerProfiles unitId={unitId}/>
     </CardHeader>
     <CardContent>
-      <POIUnitAnalysis id={id}/>
+      <POIUnitAnalysis id={unitId}/>
     </CardContent>
   </Card>
 }

--- a/frontend/components/poiu/PlayerMatchPOIUSection.js
+++ b/frontend/components/poiu/PlayerMatchPOIUSection.js
@@ -40,6 +40,7 @@ export default function PlayerMatchPOIUSection() {
     return data
   }
 
+  // this is just the async state management for fetch.
   let { isPending, error, data, refetch } = useQuery({
     queryKey: [`getUnitsByPlayerId`],
     queryFn: async ()=> {
@@ -51,7 +52,6 @@ export default function PlayerMatchPOIUSection() {
 
 
   // listen to the changes in player and situation and get and set the currentPOIU and allPlayerMatchPOIUs
-
   useEffect(()=> {
     if (!currentPlayer) return //
 
@@ -64,8 +64,6 @@ export default function PlayerMatchPOIUSection() {
   if (!currentPlayer) {
     return <></>
   }
-
-  // console.log(isPending, error, data)
 
   if (isPending) {
     return "Loading..."

--- a/frontend/components/poiu/PlayerMatchPOIUSection.js
+++ b/frontend/components/poiu/PlayerMatchPOIUSection.js
@@ -1,0 +1,82 @@
+import { useEffect } from 'react'
+
+import {
+  useQuery,
+  useQueryClient
+} from '@tanstack/react-query'
+
+import POIUnitCard from "@/components/poiu/POIUnitCard"
+
+import { useGlobalState } from '../state_providers/GlobalState'
+
+import { getUnitsByPlayerId } from "@/utils/api/players"
+
+export default function PlayerMatchPOIUSection() {
+  const queryClient = useQueryClient();
+  const {
+    currentPlayer,
+    currentSituation,
+    setCurrentPlayerPOIU,
+    currentPlayerPOIU,
+    setAllPlayerMatchPOIUs,
+  } = useGlobalState()
+
+  const getMatchedPOIUs = async () => {
+    if (!currentPlayer) return // guard if there is no player.
+
+    // call the backend.
+    const data = await getUnitsByPlayerId({
+      playerId: currentPlayer.playerId,
+      situation:currentSituation
+    })
+
+    // set the list used for the select
+    setAllPlayerMatchPOIUs(data)
+    // get the first item and pass it in
+    // this will be changed from the select
+    setCurrentPlayerPOIU(data[0])
+
+    // return the data incase we want to use it later.
+    return data
+  }
+
+  let { isPending, error, data, refetch } = useQuery({
+    queryKey: [`getUnitsByPlayerId`],
+    queryFn: async ()=> {
+      return await getMatchedPOIUs()
+    },
+    enabled: false, // this will only fetch once you get a player
+    staleTime: Infinity,
+  })
+
+
+  // listen to the changes in player and situation and get and set the currentPOIU and allPlayerMatchPOIUs
+
+  useEffect(()=> {
+    if (!currentPlayer) return //
+
+    queryClient.invalidateQueries(`getUnitsByPlayerId`)
+    refetch()
+  },[currentPlayer, currentSituation])
+
+
+  // if no player show nothing.
+  if (!currentPlayer) {
+    return <></>
+  }
+
+  // console.log(isPending, error, data)
+
+  if (isPending) {
+    return "Loading..."
+  }
+
+  return <>
+    <POIUnitCard
+      team={currentPlayer.fullTeamName.default}
+      isPlayerMatchPOIU={true}
+      isSimilarMatchPOIU={false}
+      unitId={currentPlayerPOIU}
+    />
+  </>
+}

--- a/frontend/components/poiu/SimilarPOIUSection.js
+++ b/frontend/components/poiu/SimilarPOIUSection.js
@@ -18,7 +18,6 @@ export default function SimilarPOIUSection() {
     currentPlayerPOIU,
     currentSimilarPOIU,
     currentSituation,
-    allPlayerMatchPOIUs,
     setCurrentSimilarPOIU,
     setAllSimilarPOIUs
   } = useGlobalState()
@@ -53,17 +52,15 @@ export default function SimilarPOIUSection() {
   useEffect(()=> {
     if (!currentPlayer) return // guard
     if (!currentPlayerPOIU) return // guard
-    console.log("FETCHED HERE")
+
     queryClient.invalidateQueries(`getSimilarUnitsByPoiu`)
     refetch()
-
   }, [currentPlayer, currentSituation, currentPlayerPOIU, setCurrentSimilarPOIU])
 
   // if no player show nothing.
   if (!currentPlayer) {
     return <></>
   }
-
 
   if (isPending) {
     return "Loading..."

--- a/frontend/components/poiu/SimilarPOIUSection.js
+++ b/frontend/components/poiu/SimilarPOIUSection.js
@@ -1,0 +1,81 @@
+import { useEffect } from 'react'
+
+import {
+  useQuery,
+  useQueryClient
+} from '@tanstack/react-query'
+
+import POIUnitCard from "@/components/poiu/POIUnitCard"
+
+import { useGlobalState } from '../state_providers/GlobalState'
+
+import { getSimilarUnitsByPoiu } from '@/utils/api/players'
+
+export default function SimilarPOIUSection() {
+  const queryClient = useQueryClient();
+  const {
+    currentPlayer,
+    currentPlayerPOIU,
+    currentSimilarPOIU,
+    currentSituation,
+    allPlayerMatchPOIUs,
+    setCurrentSimilarPOIU,
+    setAllSimilarPOIUs
+  } = useGlobalState()
+
+  const getSimilarPOIUs = async () => {
+    if (!currentPlayerPOIU) return
+    const data = await getSimilarUnitsByPoiu({
+      poiuId: currentPlayerPOIU,
+      situation: currentSituation
+    })
+    console.log("getSimilarPOIUs")
+    console.log(data)
+
+    // set the list used for the select
+    setAllSimilarPOIUs(data)
+    // get the first item and pass it in
+    // this will be changed from the select
+    setCurrentSimilarPOIU(data[0])
+    return data
+  }
+
+  let { isPending, error, data, refetch } = useQuery({
+    queryKey: [`getSimilarUnitsByPoiu`],
+    queryFn: async ()=> {
+      return await getSimilarPOIUs()
+    },
+    enabled: false, // this will only fetch once you get a player
+    staleTime: Infinity,
+  })
+
+  // listen to changes in the current poiu and fetch it.
+  useEffect(()=> {
+    if (!currentPlayer) return // guard
+    if (!currentPlayerPOIU) return // guard
+    console.log("FETCHED HERE")
+    queryClient.invalidateQueries(`getSimilarUnitsByPoiu`)
+    refetch()
+
+  }, [currentPlayer, currentSituation, currentPlayerPOIU, setCurrentSimilarPOIU])
+
+  // if no player show nothing.
+  if (!currentPlayer) {
+    return <></>
+  }
+
+
+  if (isPending) {
+    return "Loading..."
+  }
+
+  return <>
+    <POIUnitCard
+      team={currentPlayer.fullTeamName.default}
+      isSimilarMatchPOIU={true}
+      isPlayerMatchPOIU={false}
+      unitId={currentSimilarPOIU}
+    />
+  </>
+
+}

--- a/frontend/components/state_providers/GlobalState.js
+++ b/frontend/components/state_providers/GlobalState.js
@@ -1,0 +1,39 @@
+import {createContext, useContext, useState} from 'react'
+
+
+export const GlobalState = createContext({})
+
+
+export const useGlobalState = function () {
+  const globalState = useContext(GlobalState)
+  return globalState
+}
+
+
+export default function GlobalStateProvider({children}) {
+  // this will set in search and used elsewhere.
+  const [currentPlayer, setCurrentPlayer] = useState()
+
+  // default is 5on5, set in Situation tabs.
+  const [currentSituation, setCurrentSituation] = useState("5on5")
+
+  // match set to first POIU.
+  const [currentPlayerPOIU, setCurrentPlayerPOIU] = useState()
+  // list of player match POIUs
+  const [allPlayerMatchPOIUs, setAllPlayerMatchPOIUs] = useState([])
+  // state for similar POIUs
+  const [currentSimilarPOIU, setCurrentSimilarPOIU] = useState()
+  // list of similiar POIU ids.
+  const [allSimilarPOIUs, setAllSimilarPOIUs] = useState([])
+
+  return <GlobalState.Provider value={{
+    currentPlayer, setCurrentPlayer,
+    currentSituation, setCurrentSituation,
+    currentPlayerPOIU, setCurrentPlayerPOIU,
+    allPlayerMatchPOIUs, setAllPlayerMatchPOIUs,
+    currentSimilarPOIU, setCurrentSimilarPOIU,
+    allSimilarPOIUs, setAllSimilarPOIUs,
+  }}>
+    {children}
+  </GlobalState.Provider>
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,16 +1,18 @@
 import "@/styles/globals.css";
 
 import {
-  QueryClient,
   QueryClientProvider,
-  useQuery,
 } from '@tanstack/react-query'
 
 import queryClient from "@/utils/queryClient";
 
+import GlobalStateProvider from "@/components/state_providers/GlobalState"
+
 export default function App({ Component, pageProps }) {
-  return <QueryClientProvider client={queryClient}>
-    <Component {...pageProps} />;
-  </QueryClientProvider>
+  return <GlobalStateProvider>
+    <QueryClientProvider client={queryClient}>
+      <Component {...pageProps} />;
+    </QueryClientProvider>
+  </GlobalStateProvider>
 
 }

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -15,18 +15,12 @@ export default function Home() {
       <PlayerSearchInput />
       <SituationTabs />
 
-      {/* Just removing the tabs cards for testing  */
-        true &&
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <PlayerMatchPOIUSection />
-          {/* <POIUnitCard
-            title={`Best POIU Comparable`}
-            team={"Toronto Maple Leafs"}
-            isSimilarMatchPOIU={true}
-          /> */}
-          <SimilarPOIUSection />
-        </div>
-      }
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <PlayerMatchPOIUSection />
+        <SimilarPOIUSection />
+      </div>
+
     </div>
   );
 }

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,8 +1,14 @@
 
 import PlayerSearchInput from "@/components/player/PlayerSearchInput";
-import POIUnitCard from "@/components/poiu/POIUnitCard"
+
+import PlayerMatchPOIUSection from '@/components/poiu/PlayerMatchPOIUSection'
+import SimilarPOIUSection from "@/components/poiu/SimilarPOIUSection";
 import SituationTabs from "@/components/controls/SituationTabs";
 export default function Home() {
+
+
+
+
   return (
     <div className="container mx-auto py-6 px-4">
       <h1 className="text-3xl font-bold text-center mb-8">NHL Player On Ice Unit (POIU) Comparison Tool</h1>
@@ -10,19 +16,17 @@ export default function Home() {
       <SituationTabs />
 
       {/* Just removing the tabs cards for testing  */
-        false &&
+        true &&
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <POIUnitCard
-            title={`Connor Mcdavid's most common POIU`}
-            team={"Edmonton Oilers"}
-          />
-          <POIUnitCard
+          <PlayerMatchPOIUSection />
+          {/* <POIUnitCard
             title={`Best POIU Comparable`}
             team={"Toronto Maple Leafs"}
-          />
+            isSimilarMatchPOIU={true}
+          /> */}
+          <SimilarPOIUSection />
         </div>
       }
-
     </div>
   );
 }

--- a/frontend/utils/api/players.js
+++ b/frontend/utils/api/players.js
@@ -5,3 +5,21 @@ export async function  searchPlayers({name}) {
   const data = await response.json()
   return data
 }
+
+export async function getUnitsByPlayerId({playerId, situation}) {
+  const response = await fetch(`${BASE_URL}/get_units_by_player_id?player_id=${playerId}&situation=${situation}`)
+  const data = await response.json()
+  return data
+}
+
+export async function getPlayersByPoiu({poiuId}) {
+  const response = await fetch(`${BASE_URL}/get_players_by_poiu?poiu=${poiuId}`)
+  const data = await response.json()
+  return data
+}
+
+export async function getSimilarUnitsByPoiu({ poiuId, situation }) {
+  const response = await fetch(`${BASE_URL}/get_similar_units_by_poiu?poiu=${poiuId}&situation=${situation}`)
+  const data = await response.json()
+  return data
+}


### PR DESCRIPTION
Implements #20 and a lot of things in here https://github.com/dgmouris/dva_6242_project/issues/12 that I haven't necessarily been explicit about.

This implements three endpoints backend endpoints.
- get_units_by_player_id
gets the possible units for our player searched for (check the 
- get_players_by_poiu
fetches the players by position 
- get_similar_units_by_poiu
This right now just gets random poius but it'll be a good place for @driggs05 to put his similarity algorithm.

 This also does quite a few things in the frontend. 
 - triggers a poiu fetch on click for a player searched
 - triggers fetching similar poiu on selecting a player match poiu

This also sets up the frontend to be ready for charts now.

Demo below.
![rendering_profiles](https://github.com/user-attachments/assets/febedfe1-a0b5-40b2-84dc-80c026bb0afa)

